### PR TITLE
Add explicit sizes to each texture in the silt strider generator

### DIFF
--- a/00 BATs/Textures/_silt_strider_atlas_generator.bat
+++ b/00 BATs/Textures/_silt_strider_atlas_generator.bat
@@ -1,28 +1,31 @@
 @echo off
 if not exist ATL mkdir ATL
-for /f %%i in ('magick convert tx_siltstrider_skin_00.dds -format %%w info:') do set resolutionW=%%i
+for /f %%i in ('magick convert tx_siltstrider_skin_00.dds -format %%w info:') do set width=%%i
 
-magick convert tx_siltstrider_skin_00.dds tx_siltstrider_skin_01.dds -append ATL/temp1.bmp
-magick convert tx_siltstrider_skin_04.dds tx_siltstrider_skin_04.dds -rotate 90 +append ATL/temp2.bmp
-magick convert tx_siltstrider_skin_07.dds tx_siltstrider_skin_07.dds -rotate 90 +append ATL/temp3.bmp
-magick convert tx_siltstrider_skin_02.dds tx_siltstrider_skin_03.dds +append ATL/temp4.bmp
-magick convert tx_siltstrider_stem_01.dds tx_siltstrider_stem_01.dds -append ATL/temp5.bmp
+set /a half=%width%/2
+set /a quarter=%width%/4
+set /a eighth=%width%/4
+magick convert tx_siltstrider_skin_00.dds tx_siltstrider_skin_01.dds -resize %width% -append ATL/temp1.bmp
+magick convert tx_siltstrider_skin_04.dds tx_siltstrider_skin_04.dds -resize %quarter% -rotate 90 +append ATL/temp2.bmp
+magick convert tx_siltstrider_skin_07.dds tx_siltstrider_skin_07.dds -resize %quarter% -rotate 90 +append ATL/temp3.bmp
+magick convert tx_siltstrider_skin_02.dds tx_siltstrider_skin_03.dds -resize %half% +append ATL/temp4.bmp
+magick convert tx_siltstrider_stem_01.dds tx_siltstrider_stem_01.dds -resize %quarter% -append ATL/temp5.bmp
 magick convert ATL/temp5.bmp tx_siltstrider_stem_00.dds -layers merge -gravity north -append ATL/temp6.bmp
-magick convert tx_siltstrider_skin_09.dds tx_siltstrider_skin_12.dds -append ATL/temp7.bmp
-magick convert tx_siltstrider_skin_11.dds -rotate -90 +append ATL/temp8.bmp
-magick convert tx_siltstrider_skin_08.dds tx_siltstrider_skin_13.dds tx_siltstrider_skin_13.dds ATL/temp8.bmp -rotate 90 +append ATL/temp9.bmp
-magick convert tx_siltstrider_skin_05.dds tx_siltstrider_skin_05.dds -append ATL/temp10.bmp 
-magick convert ATL/temp10.bmp ATL/temp10.bmp ATL/temp10.bmp tx_siltstrider_skin_06.dds +append ATL/temp11.bmp
-magick convert ATL/temp6.bmp ATL/temp7.bmp tx_creature_duskyalit_09.dds +append ATL/temp12.bmp
- 
-magick convert ATL/temp1.bmp ATL/temp2.bmp ATL/temp3.bmp ATL/temp4.bmp ATL/temp12.bmp ATL/temp9.bmp ATL/temp11.bmp -resize %resolutionW% -append -define dds:compression=dxt1 ATL/atlad_siltstrider.dds
+magick convert tx_siltstrider_skin_09.dds tx_siltstrider_skin_12.dds -resize %quarter% -append ATL/temp7.bmp
+magick convert tx_siltstrider_skin_11.dds -resize %quarter% -rotate -90 +append ATL/temp8.bmp
+magick convert tx_siltstrider_skin_08.dds tx_siltstrider_skin_13.dds tx_siltstrider_skin_13.dds -resize %quarter% ATL/temp8.bmp -rotate 90 +append ATL/temp9.bmp
+magick convert tx_siltstrider_skin_05.dds tx_siltstrider_skin_05.dds -resize %quarter% -append ATL/temp10.bmp
+magick convert ATL/temp10.bmp ATL/temp10.bmp ATL/temp10.bmp ( tx_siltstrider_skin_06.dds -resize %quarter% ) +append ATL/temp11.bmp
+magick convert ATL/temp6.bmp ATL/temp7.bmp ( tx_creature_duskyalit_09.dds -resize %half% ) +append ATL/temp12.bmp
 
-magick convert tx_siltstrider_dead_02.dds tx_siltstrider_dead_03.dds +append ATL/temp110.bmp
-magick convert tx_siltstrider_dead_04.dds tx_siltstrider_dead_04.dds -rotate 90 +append ATL/temp120.bmp
-magick convert tx_siltstrider_dead_05.dds tx_siltstrider_dead_05.dds -append ATL/temp130.bmp
-magick convert tx_siltstrider_dead_06.dds tx_siltstrider_dead_11.dds ATL/temp130.bmp ATL/temp130.bmp +append ATL/temp140.bmp
+magick convert ATL/temp1.bmp ATL/temp2.bmp ATL/temp3.bmp ATL/temp4.bmp ATL/temp12.bmp ATL/temp9.bmp ATL/temp11.bmp -append -define dds:compression=dxt1 ATL/atlad_siltstrider.dds
 
-magick convert tx_siltstrider_dead_00.dds tx_siltstrider_dead_01.dds ATL/temp110.bmp tx_siltstrider_dead_07.dds ATL/temp120.bmp ATL/temp140.bmp -resize %resolutionW% -append -define dds:compression=dxt1 ATL/atlad_siltstrider_d.dds
+magick convert tx_siltstrider_dead_02.dds tx_siltstrider_dead_03.dds -resize %half% +append ATL/temp110.bmp
+magick convert tx_siltstrider_dead_04.dds tx_siltstrider_dead_04.dds -resize %quarter% -rotate 90 +append ATL/temp120.bmp
+magick convert tx_siltstrider_dead_05.dds tx_siltstrider_dead_05.dds -resize %quarter% -append ATL/temp130.bmp
+magick convert tx_siltstrider_dead_06.dds tx_siltstrider_dead_11.dds -resize %quarter% ATL/temp130.bmp ATL/temp130.bmp +append ATL/temp140.bmp
+
+magick convert tx_siltstrider_dead_00.dds tx_siltstrider_dead_01.dds -resize %width% ATL/temp110.bmp ( tx_siltstrider_dead_07.dds -resize %width% ) ATL/temp120.bmp ATL/temp140.bmp -append -define dds:compression=dxt1 ATL/atlad_siltstrider_d.dds
 
 cd ATL
 del "temp1.bmp"


### PR DESCRIPTION
This makes sure that the atlas generates correctly even when the sizes of the textures aren't all the same relative to each other as they are in the vanilla textures (e.g. if some of the textures used for the atlas are higher resolution textures, but not all).

This may or may not be an issue referenced by the README, as the way it's worded could also refer to textures whose width/height ratios have changed compared to vanilla:
> If the new textures are different proportions than vanilla, the atlas may be generated incorrectly.

This MR is for the simple way of doing this, which is to add `-resize` commands to every input texture. 

Note that I've tested it, but only using Wine on Linux, and while that should behave identically, I can't guarantee it.

## Making things complicated

I don't think the simple way really scales well to every atlas in the project, as all the resizes make the generator scripts longer and harder to read, and the lack of inline arithmetic (as far as I can tell) makes it a bit messy. However I'm not sure what sort of improvement would be considered acceptable since it would significantly change the workflow for atlas generation, so I thought I'd also bring that up (the discussion can be moved to an issue if you'd prefer).

I spent some time playing around with a python script which takes a template file, instead of separate scripts per atlas. Note that the following is a mock-up, though I had a working generator for a slightly simpler (but flawed) template format. 

The script can also handle things such as cleaning up temporary files automatically, creating parent directories, and setting the compression for dds files (which could even be user-configurable given that [OpenMW may support BC7](https://gitlab.com/OpenMW/openmw/-/issues/6885) in future).

E.g.
```yaml
# Ratio of the atlas width, as a [width, height] tuple
# We could probably omit the height, since the script will apply the resize before any other commands
# such as rotation.
# The purpose of this is not to forcibly correct textures which have completely different aspect ratios
# than what was expected.
ratios:
- tx_siltstrider_skin_00.dds: [1, 1]
- tx_siltstrider_skin_01.dds: [1, 1]
- tx_siltstrider_skin_04.dds: [1/4, 1/2]
- tx_siltstrider_skin_07.dds: [1/4, 1/2]
- tx_siltstrider_skin_02.dds: [1/2, 1/2]
- tx_siltstrider_skin_03.dds: [1/2, 1/2]
- tx_siltstrider_stem_00.dds: [1/4, 1/8]
- tx_siltstrider_stem_01.dds: [1/4, 1/4]
- tx_siltstrider_skin_05.dds: [1/4, 1/8]
- tx_siltstrider_skin_06.dds: [1/4, 1/4]
- tx_siltstrider_skin_08.dds: [1/4, 1/4]
- tx_siltstrider_skin_09.dds: [1/4, 1/4]
- tx_siltstrider_skin_11.dds: [1/4, 1/4]
- tx_siltstrider_skin_12.dds: [1/4, 1/4]
- tx_siltstrider_skin_13.dds: [1/4, 1/4]
- tx_creature_duskyalit_09.dds: [1/2, 1/2]

commands:
- tx_siltstrider_skin_00.dds tx_siltstrider_skin_01.dds -append ATL/temp1.bmp
- tx_siltstrider_skin_04.dds tx_siltstrider_skin_04.dds -rotate 90 +append ATL/temp2.bmp
- tx_siltstrider_skin_07.dds tx_siltstrider_skin_07.dds -rotate 90 +append ATL/temp3.bmp
- tx_siltstrider_skin_02.dds tx_siltstrider_skin_03.dds +append ATL/temp4.bmp
- tx_siltstrider_stem_01.dds tx_siltstrider_stem_01.dds -append ATL/temp5.bmp
- ATL/temp5.bmp tx_siltstrider_stem_00.dds -layers merge -gravity north -append ATL/temp6.bmp
- tx_siltstrider_skin_09.dds tx_siltstrider_skin_12.dds -append ATL/temp7.bmp
- tx_siltstrider_skin_11.dds -rotate -90 +append ATL/temp8.bmp
- tx_siltstrider_skin_08.dds tx_siltstrider_skin_13.dds tx_siltstrider_skin_13.dds ATL/temp8.bmp -rotate 90 +append ATL/temp9.bmp
- tx_siltstrider_skin_05.dds tx_siltstrider_skin_05.dds -append ATL/temp10.bmp
- ATL/temp10.bmp ATL/temp10.bmp ATL/temp10.bmp tx_siltstrider_skin_06.dds +append ATL/temp11.bmp
- ATL/temp6.bmp ATL/temp7.bmp tx_creature_duskyalit_09.dds +append ATL/temp12.bmp
- ATL/temp1.bmp ATL/temp2.bmp ATL/temp3.bmp ATL/temp4.bmp ATL/temp12.bmp ATL/temp9.bmp ATL/temp11.bmp -append ATL/atlad_siltstrider.dds
```
I was thinking there are two decent options for the formatting:

One is to use something like yaml (above) and create a proper python package for the atlas generator tool (since we'd need at bare minimum to deal with the yaml library dependency).

The other (below) is to do do a simple line by line parser with headers and key-value pairs split on the equals sign, which would depend only on the python standard library and could be included as a single script. It would have some issues, such as there would be no easy way to split a command over multiple lines, and it would be more prone to breaking if the file names contain unusual characters.

```ini
[ratios]
tx_siltstrider_skin_00.dds = 1
tx_siltstrider_skin_01.dds = 1
...

[commands]
tx_siltstrider_skin_00.dds tx_siltstrider_skin_01.dds -append ATL/temp1.bmp
tx_siltstrider_skin_04.dds tx_siltstrider_skin_04.dds -rotate 90 +append ATL/temp2.bmp
...
```